### PR TITLE
Improve flashcards layout and styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -87,11 +87,13 @@ button:hover {
 
 .flashcard {
   perspective: 1000px;
+  cursor: pointer;
 }
 
 .flashcard-inner {
   position: relative;
   width: 100%;
+  height: 100%;
   transform-style: preserve-3d;
   transition: transform 0.6s;
 }
@@ -104,12 +106,23 @@ button:hover {
 .flashcard-back {
   position: absolute;
   width: 100%;
+  height: 100%;
   backface-visibility: hidden;
   padding: 1rem;
   background: var(--card-bg);
-  border-radius: 8px;
+  border-radius: 12px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: box-shadow 0.3s, transform 0.3s;
 }
 
 .flashcard-back {
   transform: rotateY(180deg);
+}
+
+.flashcard:hover .flashcard-front,
+.flashcard:hover .flashcard-back {
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
 }

--- a/flashcards.html
+++ b/flashcards.html
@@ -26,16 +26,16 @@
     </div>
   </header>
   <main>
-  <div class="max-w-xl mx-auto p-4 text-center">
-    <div id="flashcard" class="flashcard mb-4" onclick="flipCard()">
+  <div class="flex flex-col items-center justify-center min-h-[80vh] px-4 text-center">
+    <div id="flash-progress" class="mb-2 text-sm text-gray-600"></div>
+    <div id="flashcard" class="flashcard w-full max-w-md h-64 mb-4" onclick="flipCard()">
       <div class="flashcard-inner">
-        <div class="flashcard-front card text-lg text-center"></div>
-        <div class="flashcard-back card text-lg text-center"></div>
+        <div class="flashcard-front card text-lg flex items-center justify-center"></div>
+        <div class="flashcard-back card text-lg flex items-center justify-center"></div>
       </div>
     </div>
-    <div id="flash-progress" class="mb-4 text-sm text-gray-600"></div>
-    <div class="flex justify-center space-x-2">
-      <button onclick="prevCard()">Prev</button>
+    <div class="flex gap-4">
+      <button onclick="prevCard()">Previous</button>
       <button onclick="nextCard()">Next</button>
       <button onclick="shuffleCards()">Shuffle</button>
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -68,6 +68,7 @@ function flipCard() {
 function showFlashcard() {
   const card = document.getElementById('flashcard');
   if (!card) return;
+  card.classList.remove('flip');
   const front = card.querySelector('.flashcard-front');
   const back = card.querySelector('.flashcard-back');
   const item = flashcards[flashIndex];


### PR DESCRIPTION
## Summary
- center flashcards container and add progress display at the top
- smooth flip animation with drop shadows
- reset flipped state when moving between cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e9db98934832fa66a85e89ac12928