### PR TITLE
Add structured exam tips content

### DIFF
--- a/exam-tips.html
+++ b/exam-tips.html
@@ -26,9 +26,61 @@
     </div>
   </header>
   <main>
-  <div class="max-w-3xl mx-auto p-4">
-    <p class="card">Remember to read each question carefully and manage your time wisely!</p>
-  </div>
+    <div class="max-w-3xl mx-auto p-4 space-y-4">
+      <div class="bg-blue-50 border-l-4 border-blue-400 p-4">
+        <p class="font-semibold">Did you know? Only 50 of the 65 questions count toward your score.</p>
+      </div>
+      <details class="card" open>
+        <summary class="font-semibold cursor-pointer mb-2">1. Exam Structure</summary>
+        <ul class="list-disc ml-6 space-y-1">
+          <li>Total number of questions: 65</li>
+          <li>Only 50 questions count toward the score; the other 15 are unscored experimental questions</li>
+          <li>You won’t know which questions are scored or not during the test</li>
+          <li>Passing score is approximately 700 out of 1000 (~70%)</li>
+          <li>All questions are multiple choice or multiple response</li>
+          <li>Time allowed: 90 minutes</li>
+          <li>Exam is available in English, Portuguese, Spanish, and other major languages</li>
+          <li>Cost: $100 USD</li>
+        </ul>
+      </details>
+      <details class="card">
+        <summary class="font-semibold cursor-pointer mb-2">2. Scoring</summary>
+        <ul class="list-disc ml-6 space-y-1">
+          <li>Only correct answers count toward your score</li>
+          <li>No partial credit on multi-response questions</li>
+          <li>Unanswered questions are marked as incorrect</li>
+          <li>AWS does not reveal the exact weight of each domain</li>
+        </ul>
+      </details>
+      <details class="card">
+        <summary class="font-semibold cursor-pointer mb-2">3. Strategy</summary>
+        <ul class="list-disc ml-6 space-y-1">
+          <li>Flag questions to return to them later if unsure</li>
+          <li>Use process of elimination when confused</li>
+          <li>Read all answer choices carefully — some may be similar but only one is correct</li>
+          <li>Practice timing — average ~1.3 minutes per question</li>
+          <li>Focus on understanding concepts, not memorizing definitions</li>
+        </ul>
+      </details>
+      <details class="card">
+        <summary class="font-semibold cursor-pointer mb-2">4. Time Management</summary>
+        <ul class="list-disc ml-6 space-y-1">
+          <li>Use the first 60 minutes to go through all questions</li>
+          <li>Leave the last 20–30 minutes to review marked/flagged questions</li>
+          <li>Avoid spending too much time on any single question</li>
+        </ul>
+      </details>
+      <details class="card">
+        <summary class="font-semibold cursor-pointer mb-2">5. Resources</summary>
+        <ul class="list-disc ml-6 space-y-1">
+          <li><a href="https://aws.amazon.com/certification/certified-cloud-practitioner/" target="_blank" class="text-blue-600 hover:underline">Official AWS Certification Page</a></li>
+          <li><a href="https://kananinirav.com/practice-exam/exams.html" target="_blank" class="text-blue-600 hover:underline">Kananini Practice Exams</a></li>
+          <li><a href="https://www.youtube.com/watch?v=NhDYbskXRgc" target="_blank" class="text-blue-600 hover:underline">YouTube – AWS Crash Course (FreeCodeCamp)</a></li>
+          <li><a href="https://www.youtube.com/watch?v=Uq5w1lnKzlk" target="_blank" class="text-blue-600 hover:underline">YouTube – AWS Cloud Overview (Simplilearn)</a></li>
+          <li><a href="https://www.youtube.com/watch?v=SOTamWNgDKc" target="_blank" class="text-blue-600 hover:underline">YouTube – Exam Tips & Prep (Andrew Brown)</a></li>
+        </ul>
+      </details>
+    </div>
   </main>
   <footer class="py-6 text-center bg-gray-100">
     <a class="hover:underline" href="index.html">Back to Home</a>


### PR DESCRIPTION
## Summary
- expand Exam Tips page with detailed study resources and testing advice
- include highlight box and collapsible sections

## Testing
- `tidy -q -e exam-tips.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ea106d388832f8b4748925fb32b7b