### PR TITLE
Update Flashcard flipping controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -87,7 +87,6 @@ button:hover {
 
 .flashcard {
   perspective: 1000px;
-  cursor: pointer;
 }
 
 .flashcard-inner {
@@ -98,7 +97,7 @@ button:hover {
   transition: transform 0.6s;
 }
 
-.flashcard.flip .flashcard-inner {
+.flashcard.is-flipped .flashcard-inner {
   transform: rotateY(180deg);
 }
 

--- a/flashcards.html
+++ b/flashcards.html
@@ -28,7 +28,7 @@
   <main>
   <div class="flex flex-col items-center justify-center min-h-[80vh] px-4 text-center">
     <div id="flash-progress" class="mb-2 text-sm text-gray-600"></div>
-    <div id="flashcard" class="flashcard w-full max-w-md h-64 mb-4" onclick="flipCard()">
+    <div id="flashcard" class="flashcard w-full max-w-md h-64 mb-4">
       <div class="flashcard-inner">
         <div class="flashcard-front card text-lg flex items-center justify-center"></div>
         <div class="flashcard-back card text-lg flex items-center justify-center"></div>
@@ -36,6 +36,7 @@
     </div>
     <div class="flex gap-4">
       <button onclick="prevCard()">Previous</button>
+      <button onclick="flipCard()">Flip Card</button>
       <button onclick="nextCard()">Next</button>
       <button onclick="shuffleCards()">Shuffle</button>
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -62,13 +62,14 @@ async function initFlashcards() {
 
 function flipCard() {
   const card = document.getElementById('flashcard');
-  card.classList.toggle('flip');
+  if (!card) return;
+  card.classList.toggle('is-flipped');
 }
 
 function showFlashcard() {
   const card = document.getElementById('flashcard');
   if (!card) return;
-  card.classList.remove('flip');
+  card.classList.remove('is-flipped');
   const front = card.querySelector('.flashcard-front');
   const back = card.querySelector('.flashcard-back');
   const item = flashcards[flashIndex];


### PR DESCRIPTION
## Summary
- replace card click with a dedicated **Flip Card** button
- toggle new `.is-flipped` class for flipping animation
- remove pointer cursor from flashcard style

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ea36bc9dc832f9c717218322d10af